### PR TITLE
Show nix flake information

### DIFF
--- a/systems/amaterasu/default.nix
+++ b/systems/amaterasu/default.nix
@@ -25,6 +25,8 @@
     programs.cosmic.enable = true;
 
     system = {
+      users = [ "jack" ];
+
       boot = {
         loader = "systemd-boot";
         secureBoot = true;

--- a/systems/default.nix
+++ b/systems/default.nix
@@ -31,6 +31,12 @@
         class = "darwin";
       };
 
+      # jack's hosts
+      jack = {
+        arch = "aarch64";
+        class = "darwin";
+      };
+
       valkyrie = {
         class = "wsl";
       };

--- a/systems/jack/default.nix
+++ b/systems/jack/default.nix
@@ -1,0 +1,13 @@
+{
+  imports = [ ./users.nix ];
+
+  garden = {
+    profiles = {
+      laptop.enable = true;
+      graphical.enable = true;
+      workstation.enable = true;
+    };
+
+    system.users = [ "jack" ];
+  };
+}

--- a/systems/jack/users.nix
+++ b/systems/jack/users.nix
@@ -1,0 +1,13 @@
+{
+  home-manager.users.jack.garden = {
+    programs = {
+      notes.enable = true;
+
+      discord.enable = true;
+      git.signingKey = "3E7C7A1B5DEDBB03";
+      fish.enable = true;
+      ghostty.enable = true;
+      chromium.enable = true;
+    };
+  };
+}

--- a/systems/jack/users.nix
+++ b/systems/jack/users.nix
@@ -7,7 +7,6 @@
       git.signingKey = "3E7C7A1B5DEDBB03";
       fish.enable = true;
       ghostty.enable = true;
-      chromium.enable = true;
     };
   };
 }


### PR DESCRIPTION
A new Darwin configuration for `jack` was defined:
*   `systems/default.nix` was updated to include `jack` as an `aarch64` Darwin host.
*   New files `systems/jack/default.nix` and `systems/jack/users.nix` were created. These define system profiles (laptop, graphical, workstation) and configure `home-manager` for `jack`, enabling programs like notes, discord, git, fish, and ghostty.

To resolve build errors:
*   `chromium.enable = true